### PR TITLE
Add three settings to allow for replacing glyphicons with font-awesome

### DIFF
--- a/jquery.bsPhotoGallery.css
+++ b/jquery.bsPhotoGallery.css
@@ -9,7 +9,7 @@
 #bsPhotoGalleryModal .modal-body {
     padding:0px !important;
 }
-#bsPhotoGalleryModal .glyphicon-remove-circle {
+#bsPhotoGalleryModal .bsp-close {
   position: absolute; 
   right: -14px; 
   top: -11px; 
@@ -18,7 +18,7 @@
   text-shadow: 1px 1px 18px #000;
 }
 
-#bsPhotoGalleryModal .glyphicon-remove-circle:hover {
+#bsPhotoGalleryModal .bsp-close:hover {
   cursor: pointer;
   opacity:.6;
   text-shadow: none;

--- a/jquery.bsPhotoGallery.js
+++ b/jquery.bsPhotoGallery.js
@@ -77,7 +77,7 @@
           var img = '<img src="' + clicked.img + '" class="img-responsive"/>';
 
           html += img;
-          html += '<span class="glyphicon glyphicon-remove-circle"></span>';
+          html += '<span class="' + settings.iconClose + ' bsp-close"></span>';
           html += '<div class="bsp-text-container">';
           
           if(alt !== null){
@@ -87,11 +87,11 @@
             html += '<p class="pText">'+pText+'</p>'
           }        
           html += '</div>';
-          html += '<a class="bsp-controls next" data-bsp-id="'+clicked.ulId+'" href="'+ (clicked.nextImg) + '"><span class="glyphicon glyphicon-chevron-right"></span></a>';
-          html += '<a class="bsp-controls previous" data-bsp-id="'+clicked.ulId+'" href="' + (clicked.prevImg) + '"><span class="glyphicon glyphicon-chevron-left"></span></a>';
+          html += '<a class="bsp-controls next" data-bsp-id="'+clicked.ulId+'" href="'+ (clicked.nextImg) + '"><span class="' + settings.iconRight + '"></span></a>';
+          html += '<a class="bsp-controls previous" data-bsp-id="'+clicked.ulId+'" href="' + (clicked.prevImg) + '"><span class="' + settings.iconLeft + '"></span></a>';
         
           $('#bsPhotoGalleryModal .modal-body').html(html);
-          $('.glyphicon-remove-circle').on('click', closeModal);
+          $('.bsp-close').on('click', closeModal);
           showHideControls();
       }
 
@@ -297,7 +297,10 @@
   $.fn.bsPhotoGallery.defaults = {
     'classes' : 'col-lg-2 col-md-2 col-sm-3 col-xs-4',
     'hasModal' : true, 
-    'fullHeight' : true
+    'fullHeight' : true,
+    'iconClose' : 'glyphicon glyphicon-remove-circle',
+    'iconLeft' : 'glyphicon glyphicon-chevron-left',
+    'iconRight' : 'glyphicon glyphicon-chevron-right'
   }
 
 


### PR DESCRIPTION
Hi Michael, thank you very much for your excellent photo gallery. I have made a small change to allow for replacing the hard-coded glyphicons with font-awesome icons (or any other) by extending the settings structure that you have provided: there are three new settings for the three icons that are used in the modal dialog. 
I had to introduce one more CSS class as well since your CSS was relying on the glyphicon class for the close button, which is now no longer guaranteed to exist.
Hope you find this useful! And thanks again for your work.
