### PR TITLE
Fixed bug that overwrote images in other modals

### DIFF
--- a/jquery.bsPhotoGallery.js
+++ b/jquery.bsPhotoGallery.js
@@ -115,7 +115,7 @@
           var theImg = ul.find('li[data-bsp-li-index="'+index+'"] img');
           var alt =  typeof theImg.attr('alt') == 'string' ? theImg.attr('alt') : null;
            
-          $('.modal-body img').attr('src', src);
+          $('#bsPhotoGalleryModal .modal-body img').attr('src', src);
           var txt = '';
           if(alt !== null){
             txt += '<h6>'+alt+'</h6>'


### PR DESCRIPTION
If a user has another modal with an image, that image would also be overwritten. This change allows the user to have images in several modals and not be overwritten.